### PR TITLE
Potential fix for code scanning alert no. 2: Disabled Spring CSRF protection

### DIFF
--- a/payment-service/src/main/java/com/hoangtien2k3/paymentservice/config/web/WebSecurityConfig.java
+++ b/payment-service/src/main/java/com/hoangtien2k3/paymentservice/config/web/WebSecurityConfig.java
@@ -40,7 +40,6 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity httpSecurity) throws Exception {
         httpSecurity
-                .csrf(AbstractHttpConfigurer::disable)
                 .authorizeRequests()
                 .antMatchers("/api/orders/**").authenticated()
                 .antMatchers("/api/carts/**").authenticated()


### PR DESCRIPTION
Potential fix for [https://github.com/Pabbati/ecommerce-microservices-docker/security/code-scanning/2](https://github.com/Pabbati/ecommerce-microservices-docker/security/code-scanning/2)

To fix the problem, we need to enable CSRF protection in the `configure` method of the `WebSecurityConfig` class. This can be done by removing the line that disables CSRF protection. By doing so, we ensure that the application is protected against CSRF attacks, which is especially important for web applications that are accessed by browser clients.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
