### PR TITLE
Potential fix for code scanning alert no. 3: Disabled Spring CSRF protection

### DIFF
--- a/promotion-service/src/main/java/com/hoangtien2k3/promotion/config/SecurityConfig.java
+++ b/promotion-service/src/main/java/com/hoangtien2k3/promotion/config/SecurityConfig.java
@@ -25,8 +25,7 @@ public class SecurityConfig {
                         .antMatchers("/storefront/**").permitAll()
                         .antMatchers("/backoffice/**").hasRole("ADMIN")
                         .anyRequest().authenticated())
-                .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt)
-                .csrf().disable();
+                .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt);
         return http.build();
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Pabbati/ecommerce-microservices-docker/security/code-scanning/3](https://github.com/Pabbati/ecommerce-microservices-docker/security/code-scanning/3)

To fix the problem, we need to enable CSRF protection in the `SecurityConfig` class. This involves removing the line that disables CSRF protection. By default, Spring Security enables CSRF protection, so we do not need to add any additional configuration to enable it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
