### PR TITLE
Potential fix for code scanning alert no. 4: Disabled Spring CSRF protection

### DIFF
--- a/rating-service/src/main/java/com/hoangtien2k3/rating/config/SecurityConfig.java
+++ b/rating-service/src/main/java/com/hoangtien2k3/rating/config/SecurityConfig.java
@@ -26,8 +26,7 @@ public class SecurityConfig {
                         .antMatchers("/storefront/**").permitAll()
                         .antMatchers("/backoffice/**").hasRole("ADMIN")
                         .anyRequest().authenticated())
-                .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt)
-                .csrf().disable();
+                .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt);
         return http.build();
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Pabbati/ecommerce-microservices-docker/security/code-scanning/4](https://github.com/Pabbati/ecommerce-microservices-docker/security/code-scanning/4)

To fix the problem, we need to enable CSRF protection in the `SecurityConfig` class. This involves removing the line that disables CSRF protection and ensuring that CSRF protection is configured correctly. The best way to fix the problem without changing existing functionality is to remove the `.csrf().disable()` line from the `filterChain` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
