### PR TITLE
Potential fix for code scanning alert no. 5: Disabled Spring CSRF protection

### DIFF
--- a/search-service/src/main/java/com/hoangtien2k3/search/config/SecurityConfig.java
+++ b/search-service/src/main/java/com/hoangtien2k3/search/config/SecurityConfig.java
@@ -28,8 +28,7 @@ public class SecurityConfig {
                         .antMatchers("/storefront/**").permitAll()
                         .antMatchers("/backoffice/**").hasRole("ADMIN")
                         .anyRequest().authenticated())
-                .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt)
-                .csrf().disable();
+                .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt);
         return http.build();
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Pabbati/ecommerce-microservices-docker/security/code-scanning/5](https://github.com/Pabbati/ecommerce-microservices-docker/security/code-scanning/5)

To fix the problem, we need to enable CSRF protection in the `SecurityConfig` class. This can be done by removing the `csrf().disable()` line from the `filterChain` method. By doing this, we ensure that CSRF protection is enabled by default, which helps prevent CSRF attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
