### PR TITLE
Potential fix for code scanning alert no. 6: Disabled Spring CSRF protection

### DIFF
--- a/tax-service/src/main/java/com/hoangtien2k3/tax/config/SecurityConfig.java
+++ b/tax-service/src/main/java/com/hoangtien2k3/tax/config/SecurityConfig.java
@@ -27,8 +27,7 @@ public class SecurityConfig {
                         .antMatchers("/storefront/**").permitAll()
                         .antMatchers("/backoffice/**").hasRole("ADMIN")
                         .anyRequest().authenticated())
-                .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt)
-                .csrf().disable();
+                .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt);
         return http.build();
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Pabbati/ecommerce-microservices-docker/security/code-scanning/6](https://github.com/Pabbati/ecommerce-microservices-docker/security/code-scanning/6)

To fix the problem, we need to enable CSRF protection in the `SecurityConfig` class. This can be done by removing the line that disables CSRF protection. By doing this, we ensure that the application is protected against CSRF attacks. The change should be made in the `filterChain` method of the `SecurityConfig` class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
