### PR TITLE
Potential fix for code scanning alert no. 7: Disabled Spring CSRF protection

### DIFF
--- a/user-service/src/main/java/com/hoangtien2k3/userservice/config/WebSecurityConfig.java
+++ b/user-service/src/main/java/com/hoangtien2k3/userservice/config/WebSecurityConfig.java
@@ -74,7 +74,6 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity httpSecurity) throws Exception {
         httpSecurity
-                .csrf(AbstractHttpConfigurer::disable)
                 .authorizeRequests()
                 .antMatchers("/api/auth/**").permitAll()
                 .antMatchers("/api/manager/token").permitAll()


### PR DESCRIPTION
Potential fix for [https://github.com/Pabbati/ecommerce-microservices-docker/security/code-scanning/7](https://github.com/Pabbati/ecommerce-microservices-docker/security/code-scanning/7)

To fix the problem, we need to enable CSRF protection in the `configure` method of the `HttpSecurity` object. This can be done by removing the line that disables CSRF protection. By default, Spring Security enables CSRF protection, so no additional configuration is needed to enable it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
