### PR TITLE
Potential fix for code scanning alert no. 8: Uncontrolled data used in path expression

### DIFF
--- a/notification-service/src/main/java/com/hoangtien2k3/notificationservice/service/impl/EmailServiceImpl.java
+++ b/notification-service/src/main/java/com/hoangtien2k3/notificationservice/service/impl/EmailServiceImpl.java
@@ -59,8 +59,14 @@ public class EmailServiceImpl implements EmailService {
                     mimeMessageHelper.setText(details.getMsgBody());
                     mimeMessageHelper.setSubject(details.getSubject());
 
-                    FileSystemResource file = new FileSystemResource(new File(details.getAttachment()));
-                    mimeMessageHelper.addAttachment(Objects.requireNonNull(file.getFilename()), file);
+                    String attachmentPath = details.getAttachment();
+                    File baseDir = new File("/path/to/attachments");
+                    File file = new File(baseDir, attachmentPath).getCanonicalFile();
+                    if (!file.getPath().startsWith(baseDir.getCanonicalPath() + File.separator)) {
+                        throw new IllegalArgumentException("Invalid attachment path");
+                    }
+                    FileSystemResource fileResource = new FileSystemResource(file);
+                    mimeMessageHelper.addAttachment(Objects.requireNonNull(fileResource.getFilename()), fileResource);
 
                     javaMailSender.send(mimeMessage);
                     return "Mail Sent Successfully";


### PR DESCRIPTION
Potential fix for [https://github.com/Pabbati/ecommerce-microservices-docker/security/code-scanning/8](https://github.com/Pabbati/ecommerce-microservices-docker/security/code-scanning/8)

To fix the problem, we need to validate the user-provided file path before using it to create a `File` object. We can ensure that the file path is within a specific directory and does not contain any path traversal sequences. This can be achieved by resolving the path against a known safe directory and checking that the resulting path is still within that directory.

1. Define a base directory where attachments are allowed to be stored.
2. Resolve the user-provided file path against this base directory.
3. Check that the resolved path is within the base directory.
4. If the path is valid, proceed with creating the `File` object; otherwise, throw an exception.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
