### PR TITLE
Potential fix for code scanning alert no. 9: Log Injection

### DIFF
--- a/common-lib/src/main/java/com/hoangtien2k3/commonlib/exception/ApiExceptionHandler.java
+++ b/common-lib/src/main/java/com/hoangtien2k3/commonlib/exception/ApiExceptionHandler.java
@@ -159,7 +159,8 @@ public class ApiExceptionHandler {
 
     private String getServletPath(WebRequest webRequest) {
         ServletWebRequest servletRequest = (ServletWebRequest) webRequest;
-        return servletRequest.getRequest().getServletPath();
+        String servletPath = servletRequest.getRequest().getServletPath();
+        return sanitizeInput(servletPath);
     }
 
     private ResponseEntity<ErrorVm> handleBadRequest(Exception ex, WebRequest request) {
@@ -179,5 +180,13 @@ public class ApiExceptionHandler {
         }
         log.error(message, ex);
         return ResponseEntity.status(status).body(errorVm);
+    }
+
+    private String sanitizeInput(String input) {
+        if (input == null) {
+            return null;
+        }
+        // Replace new-line characters and other control characters
+        return input.replaceAll("[\\r\\n]", "_");
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Pabbati/ecommerce-microservices-docker/security/code-scanning/9](https://github.com/Pabbati/ecommerce-microservices-docker/security/code-scanning/9)

To fix the log injection issue, we need to sanitize the user input before logging it. Specifically, we should remove any potentially harmful characters from the servlet path. A common approach is to replace new-line characters and other control characters with safe alternatives.

The best way to fix this problem without changing existing functionality is to sanitize the servlet path in the `getServletPath` method. We can use the `replaceAll` method to remove or replace any potentially harmful characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
