### PR TITLE
Potential fix for code scanning alert no. 17: Log Injection

### DIFF
--- a/order-service/src/main/java/com/hoangtien2k3/orderservice/security/JwtTokenFilter.java
+++ b/order-service/src/main/java/com/hoangtien2k3/orderservice/security/JwtTokenFilter.java
@@ -46,7 +46,8 @@ public class JwtTokenFilter extends OncePerRequestFilter {
                 response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid or expired token");
             }
         } catch (ExpiredJwtException e) {
-            logger.error("Token has expired for request: {}", request.getRequestURI());
+            String sanitizedRequestURI = request.getRequestURI().replace("\n", "").replace("\r", "");
+            logger.error("Token has expired for request: {}", sanitizedRequestURI);
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Token has expired");
         } catch (MalformedJwtException | SignatureException | UnsupportedJwtException | IllegalArgumentException e) {
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid token");


### PR DESCRIPTION
Potential fix for [https://github.com/Pabbati/ecommerce-microservices-docker/security/code-scanning/17](https://github.com/Pabbati/ecommerce-microservices-docker/security/code-scanning/17)

To fix the log injection issue, we need to sanitize the user input before logging it. Specifically, we should remove any newline characters from the `request.getRequestURI()` value to prevent log forging. This can be done using the `replace` method to replace newline characters with an empty string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
