### PR TITLE
Potential fix for code scanning alert no. 19: HTTP request type unprotected from CSRF

### DIFF
--- a/inventory-service/src/main/java/com/hoangtien2k3/inventoryservice/api/InventoryController.java
+++ b/inventory-service/src/main/java/com/hoangtien2k3/inventoryservice/api/InventoryController.java
@@ -29,7 +29,7 @@ public class InventoryController {
 
     // http://localhost:8083/api/inventory?productName=iphone_13&productName=iphone13_red
 
-    @GetMapping
+    @PostMapping
     @ResponseStatus(HttpStatus.OK)
     public List<InventoryResponse> isInStockNoAccessToken(@RequestHeader(name = "Authorization") String authorizationHeader,
                                                           @RequestParam List<String> productName) {


### PR DESCRIPTION
Potential fix for [https://github.com/Pabbati/ecommerce-microservices-docker/security/code-scanning/19](https://github.com/Pabbati/ecommerce-microservices-docker/security/code-scanning/19)

To fix the problem, we should change the HTTP request method for the `isInStockNoAccessToken` endpoint from `GET` to `POST`. This will ensure that the request is protected against CSRF attacks by default, as `POST` requests are typically protected by CSRF mechanisms in frameworks like Spring.

1. Change the `@GetMapping` annotation to `@PostMapping` for the `isInStockNoAccessToken` method.
2. Ensure that the method's functionality remains the same and that it continues to validate the JWT token and sanitize the product names.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
